### PR TITLE
Improve mobile layout for about section

### DIFF
--- a/files/css/about.css
+++ b/files/css/about.css
@@ -1,6 +1,25 @@
+.about-content {
+  display: flex;
+  align-items: center;
+  justify-content: space-evenly;
+  gap: 40px;
+  flex-wrap: wrap;
+}
+
+.slika-div,
+.text-div {
+  display: flex;
+  justify-content: center;
+  flex: 1 1 280px;
+}
+
+.text-div {
+  max-width: 520px;
+}
+
 .description {
-    margin: 30px;
-  }
+  margin: 30px;
+}
 .description p {
   margin-bottom: 10px;
   line-height: 1.5;
@@ -64,7 +83,30 @@
 
  
 .prof_image {
-  max-width: 100%;
+  width: min(60vw, 280px);
   border-radius: 50%;
   text-align: center;
+  height: auto;
+}
+
+@media (max-width: 768px) {
+  .about-content {
+    flex-direction: column;
+    gap: 24px;
+    text-align: center;
+  }
+
+  .text-div {
+    max-width: 100%;
+    padding: 0 20px;
+  }
+
+  .description {
+    margin: 0;
+    text-align: center;
+  }
+
+  .prof_image {
+    width: min(70vw, 220px);
+  }
 }

--- a/files/css/about.css
+++ b/files/css/about.css
@@ -1,21 +1,13 @@
-section#about {
-  padding: clamp(56px, 10vw, 120px) clamp(18px, 8vw, 140px);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: clamp(32px, 4vw, 56px);
-}
-
-section#about h2 {
-  font-size: clamp(2.4rem, 5vw, var(--text-header2));
-  text-align: center;
-  letter-spacing: 0.03em;
+.about-panel {
+  display: grid;
+  gap: clamp(32px, 5vw, 52px);
 }
 
 .about-content {
   position: relative;
   width: min(960px, 100%);
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.16), rgba(9, 107, 144, 0.18));
+  margin: 0 auto;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.16), rgba(9, 107, 144, 0.22));
   border-radius: 28px;
   padding: clamp(28px, 6vw, 60px);
   display: grid;
@@ -122,7 +114,7 @@ section#about h2 {
 }
 
 .cv-links button {
-  background: var(--color2);
+  background: rgba(9, 107, 144, 0.92);
   border: none;
   padding: 15px 28px;
   font-size: clamp(1.05rem, 2.5vw, 1.25rem);
@@ -131,14 +123,19 @@ section#about h2 {
   color: var(--text);
   font-weight: 600;
   letter-spacing: 0.04em;
-  transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
-  box-shadow: 0 10px 25px rgba(9, 107, 144, 0.35);
+  transition: transform 0.25s ease, box-shadow 0.25s ease, background 0.25s ease;
+  box-shadow: 0 10px 25px rgba(9, 107, 144, 0.28);
 }
 
 .cv-links button:hover {
-  background: var(--color3);
-  transform: translateY(-2px);
-  box-shadow: 0 16px 35px rgba(9, 107, 144, 0.4);
+  background: rgba(161, 204, 220, 0.9);
+  transform: translateY(-1px);
+  box-shadow: 0 16px 32px rgba(9, 107, 144, 0.32);
+}
+
+.cv-links button:focus-visible {
+  outline: 3px solid rgba(255, 255, 255, 0.7);
+  outline-offset: 4px;
 }
 
 @media (max-width: 900px) {
@@ -157,10 +154,6 @@ section#about h2 {
 }
 
 @media (max-width: 600px) {
-  section#about {
-    padding: clamp(48px, 12vw, 80px) clamp(16px, 6vw, 40px);
-  }
-
   .about-content {
     padding: clamp(24px, 8vw, 40px);
     gap: clamp(20px, 6vw, 32px);

--- a/files/css/about.css
+++ b/files/css/about.css
@@ -7,25 +7,26 @@
   position: relative;
   width: min(960px, 100%);
   margin: 0 auto;
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.16), rgba(9, 107, 144, 0.22));
-  border-radius: 28px;
   padding: clamp(28px, 6vw, 60px);
+  border-radius: 36px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: linear-gradient(150deg, rgba(6, 30, 48, 0.74), rgba(6, 30, 48, 0.54));
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1.2fr);
-  gap: clamp(24px, 5vw, 60px);
+  grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.1fr);
+  gap: clamp(24px, 5vw, 56px);
   align-items: center;
-  box-shadow: 0 25px 60px rgba(4, 43, 68, 0.25);
+  box-shadow: 0 18px 48px rgba(4, 26, 44, 0.34);
   overflow: hidden;
-  backdrop-filter: blur(12px);
 }
 
 .about-content::before {
   content: "";
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at 10% 20%, rgba(161, 204, 220, 0.45), transparent 60%),
-    radial-gradient(circle at 85% 80%, rgba(4, 43, 68, 0.45), transparent 65%);
-  opacity: 0.6;
+  background: radial-gradient(70% 100% at -5% 0%, rgba(161, 204, 220, 0.28), transparent 70%),
+    radial-gradient(70% 140% at 120% 40%, rgba(5, 93, 124, 0.32), transparent 65%),
+    linear-gradient(175deg, rgba(255, 255, 255, 0.08), transparent 65%);
+  opacity: 0.75;
   pointer-events: none;
 }
 
@@ -35,19 +36,41 @@
 }
 
 .about-portrait {
+  position: relative;
   display: grid;
   justify-items: center;
-  gap: 18px;
+  gap: 20px;
   text-align: center;
+  padding: clamp(8px, 1.8vw, 20px);
+}
+
+.about-portrait > * {
+  position: relative;
+  z-index: 1;
 }
 
 .prof_image {
-  width: clamp(160px, 28vw, 260px);
+  width: clamp(148px, 42vw, 232px);
   aspect-ratio: 1;
   object-fit: cover;
   border-radius: 50%;
-  border: 4px solid rgba(255, 255, 255, 0.65);
-  box-shadow: 0 12px 30px rgba(4, 43, 68, 0.32);
+  border: 3px solid rgba(255, 255, 255, 0.7);
+  box-shadow: 0 10px 26px rgba(4, 43, 68, 0.3);
+}
+
+.about-portrait::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: clamp(190px, 58vw, 272px);
+  height: clamp(190px, 58vw, 272px);
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(161, 204, 220, 0.2), transparent 70%);
+  filter: blur(0.5px);
+  z-index: 0;
+  pointer-events: none;
 }
 
 .portrait-caption {
@@ -62,32 +85,54 @@
 }
 
 .description {
-  display: flex;
-  flex-direction: column;
-  gap: clamp(14px, 3vw, 22px);
-  color: rgba(255, 255, 255, 0.92);
-  font-size: clamp(1.05rem, 2.4vw, 1.25rem);
-  line-height: 1.6;
+  display: grid;
+  gap: clamp(16px, 3vw, 26px);
+  color: rgba(255, 255, 255, 0.9);
+  font-size: clamp(1.05rem, 2.3vw, 1.22rem);
+  line-height: 1.68;
+  max-width: 60ch;
+}
+
+.description p {
+  position: relative;
+  padding-left: clamp(12px, 3vw, 22px);
+}
+
+.description p::before {
+  content: "";
+  position: absolute;
+  top: 0.65em;
+  left: 0;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: rgba(161, 204, 220, 0.9);
+  box-shadow: 0 0 0 4px rgba(161, 204, 220, 0.16);
+}
+
+.description p + p {
+  padding-top: clamp(2px, 1vw, 8px);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .about-highlights {
   display: flex;
   flex-wrap: wrap;
-  gap: 12px;
-  margin-top: clamp(10px, 2vw, 20px);
+  gap: 10px;
+  margin-top: clamp(6px, 2vw, 18px);
 }
 
 .highlight-tag {
   display: inline-flex;
   align-items: center;
-  padding: 8px 16px;
+  padding: 7px 16px;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.12);
-  color: rgba(255, 255, 255, 0.85);
-  font-size: 0.95rem;
-  letter-spacing: 0.04em;
-  backdrop-filter: blur(8px);
-  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.09);
+  color: rgba(255, 255, 255, 0.78);
+  font-size: 0.92rem;
+  letter-spacing: 0.05em;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  box-shadow: inset 0 1px 2px rgba(255, 255, 255, 0.15);
 }
 
 .videi {
@@ -99,9 +144,9 @@
 }
 
 .youtube-video {
-  border-radius: 16px;
-  border: 1px solid rgba(255, 255, 255, 0.4);
-  box-shadow: 0 15px 35px rgba(4, 43, 68, 0.25);
+  border-radius: 22px;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  box-shadow: 0 18px 40px rgba(4, 43, 68, 0.28);
 }
 
 .cv-links {
@@ -114,27 +159,26 @@
 }
 
 .cv-links button {
-  background: rgba(9, 107, 144, 0.92);
+  background: linear-gradient(135deg, rgba(9, 107, 144, 0.92), rgba(161, 204, 220, 0.8));
   border: none;
-  padding: 15px 28px;
-  font-size: clamp(1.05rem, 2.5vw, 1.25rem);
+  padding: 14px 28px;
+  font-size: clamp(1.02rem, 2.4vw, 1.2rem);
   border-radius: 999px;
   cursor: pointer;
   color: var(--text);
   font-weight: 600;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.05em;
   transition: transform 0.25s ease, box-shadow 0.25s ease, background 0.25s ease;
-  box-shadow: 0 10px 25px rgba(9, 107, 144, 0.28);
+  box-shadow: 0 12px 30px rgba(9, 107, 144, 0.26);
 }
 
 .cv-links button:hover {
-  background: rgba(161, 204, 220, 0.9);
-  transform: translateY(-1px);
-  box-shadow: 0 16px 32px rgba(9, 107, 144, 0.32);
+  transform: translateY(-2px);
+  box-shadow: 0 16px 36px rgba(9, 107, 144, 0.32);
 }
 
 .cv-links button:focus-visible {
-  outline: 3px solid rgba(255, 255, 255, 0.7);
+  outline: 3px solid rgba(255, 255, 255, 0.65);
   outline-offset: 4px;
 }
 
@@ -142,10 +186,25 @@
   .about-content {
     grid-template-columns: 1fr;
     text-align: center;
+    gap: clamp(26px, 8vw, 44px);
+  }
+
+  .about-portrait::after {
+    width: clamp(200px, 52vw, 260px);
+    height: clamp(200px, 52vw, 260px);
   }
 
   .description {
-    font-size: clamp(1.02rem, 3.4vw, 1.2rem);
+    font-size: clamp(1.02rem, 3.4vw, 1.18rem);
+    margin: 0 auto;
+  }
+
+  .description p::before {
+    top: 0.6em;
+  }
+
+  .description p + p {
+    margin-top: clamp(10px, 3vw, 16px);
   }
 
   .about-highlights {
@@ -157,6 +216,18 @@
   .about-content {
     padding: clamp(24px, 8vw, 40px);
     gap: clamp(20px, 6vw, 32px);
+  }
+
+  .description {
+    gap: clamp(14px, 6vw, 22px);
+  }
+
+  .description p {
+    padding-left: clamp(10px, 5vw, 18px);
+  }
+
+  .description p::before {
+    top: 0.55em;
   }
 
   .highlight-tag {

--- a/files/css/about.css
+++ b/files/css/about.css
@@ -1,53 +1,115 @@
-.about-content {
+section#about {
+  padding: clamp(56px, 10vw, 120px) clamp(18px, 8vw, 140px);
   display: flex;
+  flex-direction: column;
   align-items: center;
-  justify-content: space-evenly;
-  gap: 40px;
-  flex-wrap: wrap;
+  gap: clamp(32px, 4vw, 56px);
 }
 
-.slika-div,
-.text-div {
-  display: flex;
-  justify-content: center;
-  flex: 1 1 280px;
+section#about h2 {
+  font-size: clamp(2.4rem, 5vw, var(--text-header2));
+  text-align: center;
+  letter-spacing: 0.03em;
 }
 
-.text-div {
-  max-width: 520px;
+.about-content {
+  position: relative;
+  width: min(960px, 100%);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.16), rgba(9, 107, 144, 0.18));
+  border-radius: 28px;
+  padding: clamp(28px, 6vw, 60px);
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.2fr);
+  gap: clamp(24px, 5vw, 60px);
+  align-items: center;
+  box-shadow: 0 25px 60px rgba(4, 43, 68, 0.25);
+  overflow: hidden;
+  backdrop-filter: blur(12px);
+}
+
+.about-content::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 10% 20%, rgba(161, 204, 220, 0.45), transparent 60%),
+    radial-gradient(circle at 85% 80%, rgba(4, 43, 68, 0.45), transparent 65%);
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.about-content > * {
+  position: relative;
+  z-index: 1;
+}
+
+.about-portrait {
+  display: grid;
+  justify-items: center;
+  gap: 18px;
+  text-align: center;
+}
+
+.prof_image {
+  width: clamp(160px, 28vw, 260px);
+  aspect-ratio: 1;
+  object-fit: cover;
+  border-radius: 50%;
+  border: 4px solid rgba(255, 255, 255, 0.65);
+  box-shadow: 0 12px 30px rgba(4, 43, 68, 0.32);
+}
+
+.portrait-caption {
+  font-size: clamp(1rem, 2.4vw, 1.2rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.about-text {
+  width: 100%;
 }
 
 .description {
-  margin: 30px;
-}
-.description p {
-  margin-bottom: 10px;
-  line-height: 1.5;
-}
-
-
-.links {
   display: flex;
-  gap: 10px;
-  margin-top: 10px;
+  flex-direction: column;
+  gap: clamp(14px, 3vw, 22px);
+  color: rgba(255, 255, 255, 0.92);
+  font-size: clamp(1.05rem, 2.4vw, 1.25rem);
+  line-height: 1.6;
 }
 
-.youtube-video {
+.about-highlights {
   display: flex;
-  margin: 10px;
-  justify-content: center;
-  border-radius: 5%;
-  border: 1px var(--color1) solid;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: clamp(10px, 2vw, 20px);
 }
+
+.highlight-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 8px 16px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 0.95rem;
+  letter-spacing: 0.04em;
+  backdrop-filter: blur(8px);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+}
+
 .videi {
   display: flex;
   justify-content: center;
-  margin-top: 10vh;
+  flex-wrap: wrap;
+  gap: 24px;
+  width: 100%;
 }
 
-.cv-links {
-  display: flex;
-  justify-content: center;
+.youtube-video {
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  box-shadow: 0 15px 35px rgba(4, 43, 68, 0.25);
 }
 
 .cv-links {
@@ -62,51 +124,50 @@
 .cv-links button {
   background: var(--color2);
   border: none;
-  padding: 15px 25px;
-  font-size: 1.2rem;
-  border-radius: 8px;
+  padding: 15px 28px;
+  font-size: clamp(1.05rem, 2.5vw, 1.25rem);
+  border-radius: 999px;
   cursor: pointer;
   color: var(--text);
-  font-weight: bold;
-  transition: transform 0.3s ease, transform 0.2s ease;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
+  box-shadow: 0 10px 25px rgba(9, 107, 144, 0.35);
 }
 
 .cv-links button:hover {
   background: var(--color3);
-  transform: scale(1.05);
+  transform: translateY(-2px);
+  box-shadow: 0 16px 35px rgba(9, 107, 144, 0.4);
 }
 
-/* section#about {
-  background-color: #B7C3F3;
-} */
-
-
- 
-.prof_image {
-  width: min(60vw, 280px);
-  border-radius: 50%;
-  text-align: center;
-  height: auto;
-}
-
-@media (max-width: 768px) {
+@media (max-width: 900px) {
   .about-content {
-    flex-direction: column;
-    gap: 24px;
+    grid-template-columns: 1fr;
     text-align: center;
-  }
-
-  .text-div {
-    max-width: 100%;
-    padding: 0 20px;
   }
 
   .description {
-    margin: 0;
-    text-align: center;
+    font-size: clamp(1.02rem, 3.4vw, 1.2rem);
   }
 
-  .prof_image {
-    width: min(70vw, 220px);
+  .about-highlights {
+    justify-content: center;
+  }
+}
+
+@media (max-width: 600px) {
+  section#about {
+    padding: clamp(48px, 12vw, 80px) clamp(16px, 6vw, 40px);
+  }
+
+  .about-content {
+    padding: clamp(24px, 8vw, 40px);
+    gap: clamp(20px, 6vw, 32px);
+  }
+
+  .highlight-tag {
+    font-size: 0.9rem;
+    padding: 7px 14px;
   }
 }

--- a/files/css/contacts.css
+++ b/files/css/contacts.css
@@ -1,42 +1,72 @@
-.contact-list {
-    list-style: none;
-    padding: 0;
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-evenly;
-    gap: 20px;
+.contact-panel {
+  display: grid;
+  gap: clamp(28px, 5vw, 42px);
+}
+
+.contact-grid {
+  list-style: none;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: clamp(16px, 4vw, 28px);
+  width: min(900px, 100%);
+  margin: 0 auto;
+}
+
+.contact-card {
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.08), rgba(9, 107, 144, 0.18));
+  border-radius: 20px;
+  box-shadow: 0 16px 36px rgba(4, 43, 68, 0.22);
+  transition: transform 0.24s ease, box-shadow 0.24s ease;
+  backdrop-filter: blur(10px);
+}
+
+.contact-card a {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: clamp(16px, 4vw, 22px);
+  text-decoration: none;
+  color: rgba(255, 255, 255, 0.9);
+  font-size: clamp(1rem, 2.4vw, 1.15rem);
+  letter-spacing: 0.03em;
+}
+
+.contact-card img {
+  width: 28px;
+  height: 28px;
+}
+
+.contact-card span {
+  font-weight: 600;
+}
+
+.contact-card:hover,
+.contact-card:focus-within {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 44px rgba(4, 43, 68, 0.28);
+}
+
+.contact-card a:focus-visible {
+  outline: 3px solid rgba(255, 255, 255, 0.7);
+  outline-offset: 4px;
+  border-radius: 20px;
+}
+
+.site-footer {
+  text-align: center;
+  padding: clamp(24px, 6vw, 36px) clamp(16px, 6vw, 32px);
+  font-size: var(--text-footer);
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.site-footer p {
+  margin: 0;
+  letter-spacing: 0.04em;
+}
+
+@media (max-width: 540px) {
+  .contact-card a {
+    padding: clamp(14px, 6vw, 18px);
   }
-  
-  .contact-item {
-    display: inline-flex;
-    align-items: center;
-    padding: 8px 12px;
-    border-radius: 8px;
-    background: #333333;
-    color: white;
-    font-weight: bold;
-    font-size: 14px;
-    text-decoration: none;
-  }
-  
-  /* .contact-item a {
-    text-decoration: none;
-    color: var(--text);
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 10px;
-  } */
-  
-  .contact-item img {
-    width: 20px;
-    height: 20px;
-  }
-  
-  .contact-item span {
-    font-size: 20px;
-    font-weight: bold;
-    color: white;
-    text-align: center;
-    margin-bottom: 10px;
-  }
+}

--- a/files/css/footer.css
+++ b/files/css/footer.css
@@ -1,6 +1,5 @@
 footer {
-    padding: 20px;
-    text-align: center;
-    font-size: var(--text-footer);
-  }
-  
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}

--- a/files/css/friends.css
+++ b/files/css/friends.css
@@ -16,33 +16,38 @@
   display: block;
   text-decoration: none;
   color: inherit;
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.08), rgba(9, 107, 144, 0.16));
-  border-radius: 24px;
-  padding: clamp(22px, 5vw, 30px);
-  box-shadow: 0 20px 45px rgba(4, 43, 68, 0.26);
+  border-radius: 34px;
+  padding: clamp(24px, 5vw, 34px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: linear-gradient(145deg, rgba(6, 30, 48, 0.7), rgba(6, 30, 48, 0.52));
+  box-shadow: 0 18px 48px rgba(4, 28, 46, 0.32);
   overflow: hidden;
-  transition: transform 0.28s ease, box-shadow 0.28s ease;
-  backdrop-filter: blur(10px);
+  transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
 }
 
 .friend-card::after {
   content: "";
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at top right, rgba(161, 204, 220, 0.38), transparent 60%);
-  opacity: 0;
-  transition: opacity 0.28s ease;
+  background: radial-gradient(80% 140% at 110% 0%, rgba(161, 204, 220, 0.24), transparent 65%),
+    radial-gradient(70% 120% at 0% 100%, rgba(255, 255, 255, 0.12), transparent 70%);
+  opacity: 0.6;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+  transform: translate3d(-6px, -6px, 0);
+  z-index: 0;
 }
 
 .friend-card:hover,
 .friend-card:focus-visible {
-  transform: translateY(-3px);
-  box-shadow: 0 24px 52px rgba(4, 43, 68, 0.32);
+  transform: translateY(-4px);
+  box-shadow: 0 24px 58px rgba(4, 28, 46, 0.38);
+  border-color: rgba(161, 204, 220, 0.45);
 }
 
 .friend-card:hover::after,
 .friend-card:focus-visible::after {
-  opacity: 1;
+  opacity: 0.9;
+  transform: translate3d(0, 0, 0);
 }
 
 .friend-card:focus-visible {
@@ -56,7 +61,7 @@
   display: grid;
   grid-template-columns: auto 1fr auto;
   align-items: center;
-  gap: clamp(16px, 4vw, 22px);
+  gap: clamp(18px, 4vw, 24px);
 }
 
 .friend-text {
@@ -67,27 +72,28 @@
 }
 
 .friend-avatar {
-  width: 56px;
-  height: 56px;
-  border-radius: 18px;
+  width: 58px;
+  height: 58px;
+  border-radius: 50%;
   display: grid;
   place-items: center;
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.35), rgba(9, 107, 144, 0.55));
-  color: rgba(4, 43, 68, 0.85);
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.75), rgba(161, 204, 220, 0.8));
+  color: rgba(4, 43, 68, 0.82);
   font-weight: 700;
   letter-spacing: 0.06em;
   font-size: 1.05rem;
-  box-shadow: 0 10px 20px rgba(4, 43, 68, 0.25);
+  box-shadow: 0 10px 24px rgba(4, 43, 68, 0.3);
 }
 
 .friend-name {
-  font-size: clamp(1.1rem, 3vw, 1.35rem);
-  margin-bottom: 4px;
+  font-size: clamp(1.12rem, 3.2vw, 1.36rem);
+  margin-bottom: 2px;
 }
 
 .friend-description {
-  font-size: clamp(0.95rem, 2.5vw, 1.1rem);
-  color: rgba(255, 255, 255, 0.78);
+  font-size: clamp(0.96rem, 2.4vw, 1.1rem);
+  color: rgba(255, 255, 255, 0.76);
+  line-height: 1.5;
 }
 
 .friend-arrow {
@@ -107,6 +113,7 @@
     grid-template-columns: auto 1fr;
     grid-template-rows: auto auto;
     align-items: start;
+    gap: clamp(16px, 6vw, 22px);
   }
 
   .friend-arrow {
@@ -116,13 +123,12 @@
 
 @media (max-width: 480px) {
   .friend-card {
-    padding: clamp(20px, 9vw, 26px);
+    padding: clamp(20px, 9vw, 28px);
   }
 
   .friend-avatar {
     width: 52px;
     height: 52px;
-    border-radius: 16px;
     font-size: 1rem;
   }
 }

--- a/files/css/friends.css
+++ b/files/css/friends.css
@@ -1,23 +1,6 @@
-.friends-section {
-  padding: clamp(56px, 12vw, 120px) clamp(18px, 9vw, 140px);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: clamp(28px, 4vw, 48px);
-  text-align: center;
-  color: var(--text);
-}
-
-.friends-section h2 {
-  font-size: clamp(2.4rem, 5vw, var(--text-header2));
-  letter-spacing: 0.04em;
-}
-
-.friends-intro {
-  max-width: 640px;
-  font-size: clamp(1.05rem, 2.5vw, 1.25rem);
-  line-height: 1.6;
-  color: rgba(255, 255, 255, 0.8);
+.friends-panel {
+  display: grid;
+  gap: clamp(28px, 5vw, 44px);
 }
 
 .friends-grid {
@@ -25,6 +8,7 @@
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   gap: clamp(20px, 4vw, 32px);
   width: min(1040px, 100%);
+  margin: 0 auto;
 }
 
 .friend-card {
@@ -32,12 +16,12 @@
   display: block;
   text-decoration: none;
   color: inherit;
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.08), rgba(9, 107, 144, 0.15));
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.08), rgba(9, 107, 144, 0.16));
   border-radius: 24px;
-  padding: clamp(24px, 5vw, 32px);
-  box-shadow: 0 20px 45px rgba(4, 43, 68, 0.28);
+  padding: clamp(22px, 5vw, 30px);
+  box-shadow: 0 20px 45px rgba(4, 43, 68, 0.26);
   overflow: hidden;
-  transition: transform 0.35s ease, box-shadow 0.35s ease;
+  transition: transform 0.28s ease, box-shadow 0.28s ease;
   backdrop-filter: blur(10px);
 }
 
@@ -45,24 +29,25 @@
   content: "";
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at top right, rgba(161, 204, 220, 0.4), transparent 60%);
+  background: radial-gradient(circle at top right, rgba(161, 204, 220, 0.38), transparent 60%);
   opacity: 0;
-  transition: opacity 0.35s ease;
+  transition: opacity 0.28s ease;
 }
 
-.friend-card:hover {
-  transform: translateY(-6px);
-  box-shadow: 0 26px 55px rgba(4, 43, 68, 0.35);
+.friend-card:hover,
+.friend-card:focus-visible {
+  transform: translateY(-3px);
+  box-shadow: 0 24px 52px rgba(4, 43, 68, 0.32);
 }
 
-.friend-card:hover::after {
+.friend-card:hover::after,
+.friend-card:focus-visible::after {
   opacity: 1;
 }
 
 .friend-card:focus-visible {
   outline: 3px solid rgba(255, 255, 255, 0.7);
   outline-offset: 6px;
-  transform: translateY(-4px);
 }
 
 .friend-card-content {
@@ -102,26 +87,22 @@
 
 .friend-description {
   font-size: clamp(0.95rem, 2.5vw, 1.1rem);
-  color: rgba(255, 255, 255, 0.8);
+  color: rgba(255, 255, 255, 0.78);
 }
 
 .friend-arrow {
-  font-size: clamp(1.4rem, 4vw, 1.8rem);
+  font-size: clamp(1.35rem, 4vw, 1.7rem);
   color: rgba(255, 255, 255, 0.7);
-  transition: transform 0.35s ease, color 0.35s ease;
+  transition: transform 0.28s ease, color 0.28s ease;
 }
 
-.friend-card:hover .friend-arrow {
-  transform: translateX(6px);
-  color: rgba(255, 255, 255, 0.95);
+.friend-card:hover .friend-arrow,
+.friend-card:focus-visible .friend-arrow {
+  transform: translateX(4px);
+  color: rgba(255, 255, 255, 0.94);
 }
 
 @media (max-width: 720px) {
-  .friends-section {
-    padding: clamp(44px, 14vw, 72px) clamp(16px, 8vw, 36px);
-    gap: clamp(24px, 6vw, 36px);
-  }
-
   .friend-card-content {
     grid-template-columns: auto 1fr;
     grid-template-rows: auto auto;

--- a/files/css/friends.css
+++ b/files/css/friends.css
@@ -1,42 +1,147 @@
 .friends-section {
-    padding: 50px;
-    text-align: left;
-    color: var(--text);
+  padding: clamp(56px, 12vw, 120px) clamp(18px, 9vw, 140px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(28px, 4vw, 48px);
+  text-align: center;
+  color: var(--text);
+}
+
+.friends-section h2 {
+  font-size: clamp(2.4rem, 5vw, var(--text-header2));
+  letter-spacing: 0.04em;
+}
+
+.friends-intro {
+  max-width: 640px;
+  font-size: clamp(1.05rem, 2.5vw, 1.25rem);
+  line-height: 1.6;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.friends-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: clamp(20px, 4vw, 32px);
+  width: min(1040px, 100%);
+}
+
+.friend-card {
+  position: relative;
+  display: block;
+  text-decoration: none;
+  color: inherit;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.08), rgba(9, 107, 144, 0.15));
+  border-radius: 24px;
+  padding: clamp(24px, 5vw, 32px);
+  box-shadow: 0 20px 45px rgba(4, 43, 68, 0.28);
+  overflow: hidden;
+  transition: transform 0.35s ease, box-shadow 0.35s ease;
+  backdrop-filter: blur(10px);
+}
+
+.friend-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(161, 204, 220, 0.4), transparent 60%);
+  opacity: 0;
+  transition: opacity 0.35s ease;
+}
+
+.friend-card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 26px 55px rgba(4, 43, 68, 0.35);
+}
+
+.friend-card:hover::after {
+  opacity: 1;
+}
+
+.friend-card:focus-visible {
+  outline: 3px solid rgba(255, 255, 255, 0.7);
+  outline-offset: 6px;
+  transform: translateY(-4px);
+}
+
+.friend-card-content {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: clamp(16px, 4vw, 22px);
+}
+
+.friend-text {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  text-align: left;
+}
+
+.friend-avatar {
+  width: 56px;
+  height: 56px;
+  border-radius: 18px;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.35), rgba(9, 107, 144, 0.55));
+  color: rgba(4, 43, 68, 0.85);
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  font-size: 1.05rem;
+  box-shadow: 0 10px 20px rgba(4, 43, 68, 0.25);
+}
+
+.friend-name {
+  font-size: clamp(1.1rem, 3vw, 1.35rem);
+  margin-bottom: 4px;
+}
+
+.friend-description {
+  font-size: clamp(0.95rem, 2.5vw, 1.1rem);
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.friend-arrow {
+  font-size: clamp(1.4rem, 4vw, 1.8rem);
+  color: rgba(255, 255, 255, 0.7);
+  transition: transform 0.35s ease, color 0.35s ease;
+}
+
+.friend-card:hover .friend-arrow {
+  transform: translateX(6px);
+  color: rgba(255, 255, 255, 0.95);
+}
+
+@media (max-width: 720px) {
+  .friends-section {
+    padding: clamp(44px, 14vw, 72px) clamp(16px, 8vw, 36px);
+    gap: clamp(24px, 6vw, 36px);
   }
-  
-  .friends-section h2 {
-    font-size: var(--text-header2);
-    margin-bottom: 20px;
+
+  .friend-card-content {
+    grid-template-columns: auto 1fr;
+    grid-template-rows: auto auto;
+    align-items: start;
   }
-  
-  .friends-list {
-    display: flex;
-    flex-direction: column;
-    gap: 15px;
-    max-width: 600px;
+
+  .friend-arrow {
+    display: none;
   }
-  
-  .friend-item {
-    background-color: rgba(255, 255, 255, 0.1);
-    padding: 15px 20px;
-    border-radius: 10px;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    transition: background-color 0.3s ease;
+}
+
+@media (max-width: 480px) {
+  .friend-card {
+    padding: clamp(20px, 9vw, 26px);
   }
-  
-  .friend-item:hover {
-    background-color: rgba(255, 255, 255, 0.2);
+
+  .friend-avatar {
+    width: 52px;
+    height: 52px;
+    border-radius: 16px;
+    font-size: 1rem;
   }
-  
-  .friend-name {
-    font-size: 18px;
-    font-weight: bold;
-  }
-  
-  .friend-description {
-    font-size: 16px;
-    color: var(--text);
-    opacity: 0.8;
-  }
+}

--- a/files/css/header.css
+++ b/files/css/header.css
@@ -1,68 +1,70 @@
-header {
-    /* margin-top: 40px; */
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    /* margin-top: 40vh; */
-    align-items: center;
-    height: 100vh;
-  }
-  .header-image {
-    background-image: url('../images/abstract.webp');
-    background-repeat: no-repeat;
-    background-attachment: fixed;
-    background-position: center;
-    background-size: cover;
-    position: flex;
-  }
-
-  header h1 {
-    font-size: var(--text-header1);
-    text-align: center;
-    margin-top: 5vh;
-    overflow: hidden;
-    padding-bottom: 10vh;
-    z-index: 10;
-  }
-  
-  .title {
-    margin: 20px;
-    font-size: var(--text-header1);
-    text-align: left;
-  }
-  .text-div{
-    width: 80%;
-  }
-  .slika-div{
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    width: 20vw;
-    margin: 2%;
-  }
-
-  .mal-div-center {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    width: 100%;
-    text-align: center;
-  }
-
-  .scroll-div{
-    margin-top: 80vh;
-  }
-
-.language-switch{
+.header-image {
+  position: relative;
+  min-height: 100vh;
+  background-image: url('../images/abstract.webp');
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: cover;
   display: flex;
-  margin-left: 0;
-  margin-top: 20%;
-  overflow: hidden;
-  padding: 10px;
-  height: 10vh;
-  color: white;
-  filter: invert(1);
+  align-items: stretch;
 }
-  
-  
+
+.header-image::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(4, 43, 68, 0.65) 0%, rgba(4, 43, 68, 0.35) 45%, rgba(9, 107, 144, 0.25) 100%);
+  backdrop-filter: blur(4px);
+}
+
+header {
+  position: relative;
+  z-index: 1;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: clamp(32px, 8vw, 56px);
+  padding: clamp(90px, 12vw, 140px) clamp(18px, 8vw, 80px) clamp(48px, 10vw, 96px);
+  text-align: center;
+}
+
+header h1 {
+  font-size: clamp(3.5rem, 9vw, var(--text-header1));
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.95);
+}
+
+.mal-div-center {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(18px, 4vw, 28px);
+}
+
+#rolling-stones {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: clamp(1.2rem, 3.2vw, 1.6rem);
+  color: rgba(161, 204, 220, 0.92);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+#rolling-stones p {
+  margin: 0;
+  color: inherit;
+}
+
+.scroll-div {
+  margin-top: clamp(40px, 10vw, 80px);
+}
+
+@media (max-width: 768px) {
+  .header-image {
+    background-attachment: scroll;
+  }
+}

--- a/files/css/mobile.css
+++ b/files/css/mobile.css
@@ -1,61 +1,42 @@
-/* Hamburger menu styles */
+/* Hamburger menu styles (reserved for future use) */
 .hamburger-menu {
-    display: none;
-    cursor: pointer;
-    padding: 15px;
-    position: absolute;
-    top: 15px;
-    right: 15px;
-    z-index: 10000;
+  display: none;
+  cursor: pointer;
+  padding: 15px;
+  position: absolute;
+  top: 15px;
+  right: 15px;
+  z-index: 10000;
 }
 
 .hamburger-menu .bar {
-    width: 25px;
-    height: 3px;
-    background-color: var(--text);
-    margin: 5px 0;
-    transition: 0.4s;
+  width: 25px;
+  height: 3px;
+  background-color: var(--text);
+  margin: 5px 0;
+  transition: 0.4s;
 }
 
-/* Mobile navigation menu styles */
-.mobile-nav {
-    display: none;
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background-color: rgba(0, 0, 0, 0.9);
-    z-index: 9999;
-    text-align: center;
-    padding-top: 60px;
-}
-
-.mobile-nav ul {
-    list-style: none;
-    padding: 0;
-}
-
-.mobile-nav ul li {
-    padding: 15px 0;
-}
-
-.mobile-nav ul li a {
-    color: white;
-    text-decoration: none;
-    font-size: 24px;
-}
-
+/* Mobile navigation adjustments */
 @media screen and (max-width: 768px) {
-    .nav-bar {
-        display: none;
-    }
+  .nav-bar {
+    padding: clamp(14px, 7vw, 28px) clamp(16px, 8vw, 36px);
+  }
 
-    .hamburger-menu {
-        display: block;
-    }
+  .nav-bar ul {
+    width: 100%;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: clamp(10px, 5vw, 18px);
+  }
+}
 
-    .mobile-nav.active {
-        display: block;
-    }
+@media screen and (max-width: 520px) {
+  .nav-bar ul {
+    padding: clamp(10px, 6vw, 16px) clamp(18px, 7vw, 26px);
+  }
+
+  .nav-bar ul li a {
+    letter-spacing: 0.08em;
+  }
 }

--- a/files/css/nav-bar.css
+++ b/files/css/nav-bar.css
@@ -1,74 +1,79 @@
-nav {
-    background: var(--background);
-    color: var(--text);
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    text-align: center;
-    font-size: var(--text-header2);
-    overflow: hidden;
-    z-index: 10;
-    margin-top: 0;
-    position: absolute;
-    top: 0;
-    padding-top: 3vh;
-  }
-  nav ul {
-    list-style: none;
-    display: flex;
-    justify-content: center;
-    gap: 20px;
-    flex-wrap: wrap;
-  }
-  
-  nav ul li {
+.nav-bar {
+  position: sticky;
+  top: clamp(16px, 5vw, 32px);
+  z-index: 20;
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  padding: 0 clamp(18px, 8vw, 80px);
+}
+
+.nav-bar ul {
+  list-style: none;
+  display: inline-flex;
+  align-items: center;
+  gap: clamp(12px, 3vw, 28px);
+  padding: clamp(12px, 3vw, 18px) clamp(24px, 6vw, 36px);
+  margin: 0;
+  border-radius: 999px;
+  background: rgba(9, 107, 144, 0.24);
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  box-shadow: 0 14px 36px rgba(4, 43, 68, 0.28);
+  backdrop-filter: blur(10px);
+}
+
+.nav-bar ul li {
+  position: relative;
+}
+
+.nav-bar ul li a {
+  text-decoration: none;
+  color: rgba(255, 255, 255, 0.92);
+  font-size: clamp(0.95rem, 2.6vw, 1.1rem);
+  letter-spacing: 0.12em;
+  transition: color 0.25s ease;
+}
+
+.nav-bar ul li a::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -6px;
+  width: 100%;
+  height: 2px;
+  background: rgba(255, 255, 255, 0.8);
+  transform: scaleX(0);
+  transform-origin: center;
+  transition: transform 0.25s ease;
+}
+
+.nav-bar ul li a:hover,
+.nav-bar ul li a:focus-visible {
+  color: #fff;
+}
+
+.nav-bar ul li a:hover::after,
+.nav-bar ul li a:focus-visible::after {
+  transform: scaleX(1);
+}
+
+.nav-bar ul li a:focus-visible {
+  outline: none;
+}
+
+#rolling-stones {
+  max-height: 100vh;
+}
+
+@media (max-width: 768px) {
+  .nav-bar {
     position: relative;
-    overflow: hidden;
-    padding: 10px;
+    top: 0;
+    padding: clamp(18px, 8vw, 40px);
   }
-  
-  nav ul li a {
-    text-decoration: none;
-    color: var(--text);
-    padding: 10px;
-    transition: color 0.7s; /* Add transition property */
-  }
-  
-  nav ul li a:hover {
-    color: var(--text2);
-  }
-  
-  nav ul li a:hover::after {
-    content: "";
-    display: block;
+
+  .nav-bar ul {
     width: 100%;
-    height: 2px;
-    background: var(--text2);
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    transition: width 0.7s; /* Add transition property */
+    justify-content: center;
   }
-
-
-  #rolling-stones {
-    max-width: 100%;
-    max-height: 5vh;
-    padding-bottom: 5vh;
-    font-size: 2em;
-    text-align: center;
-    color: blue;
-    white-space: nowrap;
-    max-height: 100vh;
-  }
-  #rolling-stones p {
-    white-space: nowrap;
-    font-size: 1.1em;
-    text-align: center;
-    color: var(--color2);
-    margin: 0;
-    line-height: 0;
-    &:nth-of-type(5) {
-      color: var(--color4);
-    }
-  }
+}

--- a/files/css/projects.css
+++ b/files/css/projects.css
@@ -1,0 +1,115 @@
+.projects-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: clamp(20px, 4vw, 32px);
+}
+
+.project-card {
+  position: relative;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.09), rgba(9, 107, 144, 0.18));
+  border-radius: 24px;
+  padding: clamp(22px, 5vw, 32px);
+  box-shadow: 0 20px 48px rgba(4, 43, 68, 0.26);
+  display: grid;
+  gap: clamp(14px, 4vw, 20px);
+  backdrop-filter: blur(10px);
+  transition: transform 0.28s ease, box-shadow 0.28s ease;
+}
+
+.project-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 85% 15%, rgba(161, 204, 220, 0.4), transparent 60%);
+  opacity: 0;
+  transition: opacity 0.28s ease;
+}
+
+.project-card > * {
+  position: relative;
+  z-index: 1;
+}
+
+.project-card:hover,
+.project-card:focus-within {
+  transform: translateY(-3px);
+  box-shadow: 0 26px 54px rgba(4, 43, 68, 0.32);
+}
+
+.project-card:hover::after,
+.project-card:focus-within::after {
+  opacity: 1;
+}
+
+.project-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.project-header h3 {
+  font-size: clamp(1.35rem, 3.5vw, 1.6rem);
+  line-height: 1.3;
+}
+
+.project-stack {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.project-stack img {
+  width: 28px;
+  height: 28px;
+}
+
+.project-description {
+  font-size: clamp(0.98rem, 2.4vw, 1.1rem);
+  line-height: 1.6;
+  color: rgba(255, 255, 255, 0.82);
+}
+
+.project-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.project-links a {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  text-decoration: none;
+  background: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  letter-spacing: 0.03em;
+  transition: background 0.24s ease, transform 0.24s ease;
+}
+
+.project-links a img {
+  width: 20px;
+  height: 20px;
+}
+
+.project-links a:hover,
+.project-links a:focus-visible {
+  background: rgba(255, 255, 255, 0.22);
+  transform: translateY(-1px);
+}
+
+.project-links a:focus-visible {
+  outline: 3px solid rgba(255, 255, 255, 0.65);
+  outline-offset: 4px;
+}
+
+@media (max-width: 540px) {
+  .project-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 10px;
+  }
+}

--- a/files/css/section.css
+++ b/files/css/section.css
@@ -1,59 +1,76 @@
-section {
-  max-width: 1400px;
-  margin: 10px auto;
-  padding: 40px;
+.section-wrapper {
+  width: 100%;
+  padding: clamp(56px, 10vw, 120px) clamp(16px, 8vw, 140px);
+  display: flex;
+  justify-content: center;
 }
 
-section h2 {
-  font-size: var(--text-header2);
-  margin-bottom: 20px;
-}
-section h3 {
-  font-size: var(--text-header3);
-  margin-bottom: 20px;
-}
-section p,
-section ul,
-section ol {
-  font-size: var(--text-size);
-  margin-bottom: 20px;
-}
-section ul {
-  font-size: var(--text-size);
+.section-panel {
+  position: relative;
+  width: min(1100px, 100%);
+  border-radius: 30px;
+  padding: clamp(32px, 6vw, 64px);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.14), rgba(9, 107, 144, 0.2));
+  box-shadow: 0 24px 60px rgba(4, 43, 68, 0.28);
+  overflow: hidden;
+  backdrop-filter: blur(14px);
 }
 
-section#projects ul {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
-    gap: 20px;
-    }
-  
-  section#projects li {
-    width: calc(33% - 20px);
-    background-color: var(--color2);
-    border-radius: 10px;
-    padding: 20px;
-    transition: background-color 0.3s ease;
-    overflow: hidden;
+.section-panel::before,
+.section-panel::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.section-panel::before {
+  background: radial-gradient(circle at 15% 20%, rgba(161, 204, 220, 0.45), transparent 60%),
+    radial-gradient(circle at 85% 85%, rgba(4, 43, 68, 0.32), transparent 65%);
+  opacity: 0.65;
+}
+
+.section-panel::after {
+  background: linear-gradient(120deg, rgba(255, 255, 255, 0.08), transparent 65%);
+  mix-blend-mode: screen;
+}
+
+.section-panel > * {
+  position: relative;
+  z-index: 1;
+}
+
+.section-heading {
+  text-align: center;
+  display: grid;
+  gap: clamp(12px, 3vw, 18px);
+  margin-bottom: clamp(28px, 6vw, 44px);
+}
+
+.section-heading h2 {
+  font-size: clamp(2.3rem, 5vw, var(--text-header2));
+  letter-spacing: 0.035em;
+}
+
+.section-lede {
+  font-size: clamp(1.05rem, 2.6vw, 1.25rem);
+  line-height: 1.6;
+  color: rgba(255, 255, 255, 0.82);
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+@media (max-width: 720px) {
+  .section-wrapper {
+    padding: clamp(44px, 12vw, 80px) clamp(14px, 8vw, 40px);
   }
-  
-  section#projects li:hover {
-    background-color: var(--color3);
+
+  .section-panel {
+    border-radius: 26px;
+    padding: clamp(24px, 8vw, 44px);
   }
-  
-  section#projects h3 {
-    font-size: var(--text-size);
-    margin-bottom: 10px;
+
+  .section-heading {
+    margin-bottom: clamp(22px, 7vw, 32px);
   }
-  
-  section#projects p {
-    font-size: calc(var(--text-size) * 0.8);
-  }
-  
-  section#projects li img {
-    width: 50px;
-    height: 50px;
-    margin-bottom: 10px;
-    text-decoration: none;
-  }
+}

--- a/files/css/section.css
+++ b/files/css/section.css
@@ -1,19 +1,22 @@
+
 .section-wrapper {
   width: 100%;
-  padding: clamp(56px, 10vw, 120px) clamp(16px, 8vw, 140px);
+  padding: clamp(52px, 9vw, 116px) clamp(16px, 8vw, 140px);
   display: flex;
   justify-content: center;
 }
 
 .section-panel {
   position: relative;
-  width: min(1100px, 100%);
-  border-radius: 30px;
-  padding: clamp(32px, 6vw, 64px);
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.14), rgba(9, 107, 144, 0.2));
-  box-shadow: 0 24px 60px rgba(4, 43, 68, 0.28);
+  width: min(1080px, 100%);
+  padding: clamp(32px, 6vw, 68px) clamp(28px, 6vw, 72px);
+  border-radius: 40px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: radial-gradient(circle at -10% -20%, rgba(161, 204, 220, 0.28), transparent 55%),
+    radial-gradient(circle at 110% 0%, rgba(4, 43, 68, 0.46), transparent 60%),
+    linear-gradient(160deg, rgba(5, 26, 45, 0.7), rgba(5, 26, 45, 0.5));
+  box-shadow: 0 18px 54px rgba(4, 28, 46, 0.32);
   overflow: hidden;
-  backdrop-filter: blur(14px);
 }
 
 .section-panel::before,
@@ -25,14 +28,20 @@
 }
 
 .section-panel::before {
-  background: radial-gradient(circle at 15% 20%, rgba(161, 204, 220, 0.45), transparent 60%),
-    radial-gradient(circle at 85% 85%, rgba(4, 43, 68, 0.32), transparent 65%);
-  opacity: 0.65;
+  background: radial-gradient(85% 120% at 50% 0%, rgba(255, 255, 255, 0.08), transparent 70%),
+    radial-gradient(75% 120% at 50% 120%, rgba(9, 107, 144, 0.25), transparent 78%);
+  mix-blend-mode: screen;
 }
 
 .section-panel::after {
-  background: linear-gradient(120deg, rgba(255, 255, 255, 0.08), transparent 65%);
-  mix-blend-mode: screen;
+  top: auto;
+  right: 24px;
+  bottom: -45%;
+  left: 24px;
+  height: 120%;
+  border-radius: 50%;
+  background: radial-gradient(circle at 50% 0%, rgba(255, 255, 255, 0.22), transparent 70%);
+  opacity: 0.5;
 }
 
 .section-panel > * {
@@ -62,15 +71,15 @@
 
 @media (max-width: 720px) {
   .section-wrapper {
-    padding: clamp(44px, 12vw, 80px) clamp(14px, 8vw, 40px);
+    padding: clamp(40px, 12vw, 76px) clamp(14px, 8vw, 40px);
   }
 
   .section-panel {
-    border-radius: 26px;
-    padding: clamp(24px, 8vw, 44px);
+    border-radius: 32px;
+    padding: clamp(26px, 9vw, 48px) clamp(22px, 8vw, 38px);
   }
 
   .section-heading {
-    margin-bottom: clamp(22px, 7vw, 32px);
+    margin-bottom: clamp(20px, 7vw, 30px);
   }
 }

--- a/files/css/skills.css
+++ b/files/css/skills.css
@@ -1,41 +1,73 @@
-.badges {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 10px;
-    margin-bottom: 15px;
-  }
-  
-  .badge {
-    display: inline-flex;
-    align-items: center;
-    padding: 8px 12px;
-    border-radius: 8px;
-    background: #333;
-    color: white;
-    font-weight: bold;
-    font-size: 14px;
-    text-decoration: none;
-  }
-  
-  .badge img {
-    margin-right: 5px;
-    height: 20px;
-  }
-.badge.js { background: #f7df1e; color: #000; }
-.badge.java { background: #007396; }
-.badge.cpp { background: #00599c; }
-.badge.node { background: #68a063; }
-.badge.react-native { background: #61dafb; color: #000; }
-.badge.esp32 { background: #0078D7; }
-.badge.cmd, .badge.batch { background: #6e6e6e; }
-.badge.git { background: #f34f29; }
-.badge.tool { background: #444; }
-
-.icons {
-  display: flex;
-  justify-content: center;
-  margin-bottom: 10vh;
+.skills-groups {
+  display: grid;
+  gap: clamp(24px, 5vw, 36px);
 }
-.badge p{
+
+.skill-group {
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.08), rgba(9, 107, 144, 0.18));
+  border-radius: 22px;
+  padding: clamp(20px, 5vw, 32px);
+  box-shadow: 0 18px 40px rgba(4, 43, 68, 0.24);
+  backdrop-filter: blur(8px);
+  display: grid;
+  gap: clamp(16px, 4vw, 22px);
+}
+
+.skill-group h3 {
+  font-size: clamp(1.3rem, 3.6vw, 1.6rem);
+  letter-spacing: 0.02em;
+}
+
+.badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 15px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.9);
+  font-weight: 500;
+  font-size: 0.95rem;
+  letter-spacing: 0.03em;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  backdrop-filter: blur(6px);
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.badge img {
+  height: 22px;
+  width: 22px;
+  object-fit: contain;
+}
+
+.badge:hover {
+  transform: translateY(-2px);
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.badge p {
   margin: 0;
+}
+
+@media (min-width: 960px) {
+  .skills-groups {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 540px) {
+  .skill-group {
+    padding: clamp(18px, 8vw, 24px);
+  }
+
+  .badge {
+    padding: 8px 14px;
+    font-size: 0.9rem;
+  }
 }

--- a/files/css/style.css
+++ b/files/css/style.css
@@ -5,7 +5,6 @@
   font-family: "Jersey 15", sans-serif;
   font-weight: 400;
   font-style: normal;
-
   scroll-behavior: smooth;
   max-width: 100%;
   user-select: none;
@@ -35,12 +34,11 @@
 
 body {
   color: var(--text);
-  background: rgb(20, 117, 187);
-  background-color: rgb(20, 117, 187);
-  background: radial-gradient(rgb(169, 221, 214) 0%, rgba(145, 173, 194) 46%, rgba(193, 184, 200) 100%);
-  max-width: 100%;
+  background: radial-gradient(140% 140% at 0% 0%, rgba(9, 107, 144, 0.45) 0%, rgba(4, 43, 68, 0.8) 45%),
+    radial-gradient(120% 120% at 90% 10%, rgba(161, 204, 220, 0.35) 0%, rgba(4, 43, 68, 0.9) 55%),
+    #031b2d;
+  min-height: 100vh;
 }
-
 
 @keyframes fadeIn {
   0% {
@@ -63,6 +61,7 @@ body {
   color: white;
   filter: invert(1);
 }
+
 @keyframes floatAnimation {
   0% {
     transform: translateY(0);
@@ -74,7 +73,6 @@ body {
     transform: translateY(0);
   }
 }
-
 
 .scroll-up {
   position: fixed;
@@ -89,7 +87,7 @@ body {
   opacity: 0;
   transition: opacity 0.3s ease;
 }
+
 .show {
   opacity: 1;
 }
-

--- a/files/html-parts/about.html
+++ b/files/html-parts/about.html
@@ -1,32 +1,38 @@
 <section id="about">
   <h2>About Me</h2>
-    <div class="about-content">
-        <div class="slika-div">
-            <img
-                src="./files/images/IMG_2983.jpg"
-                class="prof_image"
-                alt="Profile Picture"
-              />
+  <div class="about-content">
+    <figure class="about-portrait">
+      <img
+        src="./files/images/IMG_2983.jpg"
+        class="prof_image"
+        alt="Profile Picture"
+      />
+      <figcaption class="portrait-caption">Animator & musician</figcaption>
+    </figure>
+    <div class="about-text">
+      <div class="description">
+        <p>
+          I'm a third-year student at Vegova, deeply immersed in the technical
+          gymnasium program where technology and creativity overlap in every
+          project I touch.
+        </p>
+        <p>
+          Outside the classroom I'm wrapping up my eighth year of piano studies,
+          often switching to guitar when inspiration strikes. I stay rooted in my
+          Christian faith and quietly lend my animation skills within my church
+          community whenever there's a story to bring to life.
+        </p>
+        <div class="about-highlights" aria-label="Personal highlights">
+          <span class="highlight-tag">Tech gymnasium student</span>
+          <span class="highlight-tag">Piano & guitar player</span>
+          <span class="highlight-tag">Church animator</span>
         </div>
-        <div class="text-div">
-            <div class="description">
-              <p>
-                I'm a third-year student at Vegova, deeply immersed in the technical
-                gymnasium program, where I explore technology and creativity.
-                Alongside my studies, I'm learning piano at music school for the 8th
-                year and continuing. I also have a little experience in programming
-                and stay rooted in my Christian faith.
-              </p>
-              <p>
-                In my free time, I express my creativity through piano and guitar
-                playing, and I quietly contribute as an animator within my church
-                community.
-              </p>
-            </div>
-        </div>
+      </div>
     </div>
-    <div class="videi">
-      <!-- <iframe
+  </div>
+  <div class="videi">
+    <!--
+      <iframe
         width="420"
         height="315"
         class="youtube-video"
@@ -38,12 +44,17 @@
         width="420"
         height="315"
         class="youtube-video"
-      ></iframe> -->
-    </div>
-    <div class="cv-links">
-      <!-- Add your Europass CV link below -->
-      <a href="https://europa.eu/europass/eportfolio/api/eprofile/shared-profile/maj-mohar/77ae228e-119c-4855-b3b8-db07cb0735ea?view=html" target="_blank">
-        <button>See My Europass CV</button>
-      </a>
-    </div>
-  </section>
+      ></iframe>
+    -->
+  </div>
+  <div class="cv-links">
+    <!-- Add your Europass CV link below -->
+    <a
+      href="https://europa.eu/europass/eportfolio/api/eprofile/shared-profile/maj-mohar/77ae228e-119c-4855-b3b8-db07cb0735ea?view=html"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      <button>See My Europass CV</button>
+    </a>
+  </div>
+</section>

--- a/files/html-parts/about.html
+++ b/files/html-parts/about.html
@@ -1,6 +1,6 @@
 <section id="about">
   <h2>About Me</h2>
-    <div style="display: flex; flex-direction: row; justify-content: space-evenly;">
+    <div class="about-content">
         <div class="slika-div">
             <img
                 src="./files/images/IMG_2983.jpg"
@@ -14,11 +14,13 @@
                 I'm a third-year student at Vegova, deeply immersed in the technical
                 gymnasium program, where I explore technology and creativity.
                 Alongside my studies, I'm learning piano at music school for the 8th
-                year and continuing. I also have a little experience in programming.
+                year and continuing. I also have a little experience in programming
+                and stay rooted in my Christian faith.
               </p>
               <p>
                 In my free time, I express my creativity through piano and guitar
-                playing.
+                playing, and I quietly contribute as an animator within my church
+                community.
               </p>
             </div>
         </div>

--- a/files/html-parts/about.html
+++ b/files/html-parts/about.html
@@ -1,60 +1,64 @@
-<section id="about">
-  <h2>About Me</h2>
-  <div class="about-content">
-    <figure class="about-portrait">
-      <img
-        src="./files/images/IMG_2983.jpg"
-        class="prof_image"
-        alt="Profile Picture"
-      />
-      <figcaption class="portrait-caption">Animator & musician</figcaption>
-    </figure>
-    <div class="about-text">
-      <div class="description">
-        <p>
-          I'm a third-year student at Vegova, deeply immersed in the technical
-          gymnasium program where technology and creativity overlap in every
-          project I touch.
-        </p>
-        <p>
-          Outside the classroom I'm wrapping up my eighth year of piano studies,
-          often switching to guitar when inspiration strikes. I stay rooted in my
-          Christian faith and quietly lend my animation skills within my church
-          community whenever there's a story to bring to life.
-        </p>
-        <div class="about-highlights" aria-label="Personal highlights">
-          <span class="highlight-tag">Tech gymnasium student</span>
-          <span class="highlight-tag">Piano & guitar player</span>
-          <span class="highlight-tag">Church animator</span>
+<section id="about" class="section-wrapper">
+  <div class="section-panel about-panel">
+    <div class="section-heading">
+      <h2>About Me</h2>
+    </div>
+    <div class="about-content">
+      <figure class="about-portrait">
+        <img
+          src="./files/images/IMG_2983.jpg"
+          class="prof_image"
+          alt="Profile Picture"
+        />
+        <figcaption class="portrait-caption">Animator &amp; musician</figcaption>
+      </figure>
+      <div class="about-text">
+        <div class="description">
+          <p>
+            I'm a third-year student at Vegova, deeply immersed in the technical
+            gymnasium program where technology and creativity overlap in every
+            project I touch.
+          </p>
+          <p>
+            Outside the classroom I'm wrapping up my eighth year of piano studies,
+            often switching to guitar when inspiration strikes. I stay rooted in my
+            Christian faith and quietly lend my animation skills within my church
+            community whenever there's a story to bring to life.
+          </p>
+          <div class="about-highlights" aria-label="Personal highlights">
+            <span class="highlight-tag">Tech gymnasium student</span>
+            <span class="highlight-tag">Piano &amp; guitar player</span>
+            <span class="highlight-tag">Church animator</span>
+          </div>
         </div>
       </div>
     </div>
-  </div>
-  <div class="videi">
-    <!--
-      <iframe
-        width="420"
-        height="315"
-        class="youtube-video"
-        src="https://www.youtube.com/embed/c_5o7RdhAA4"
+    <div class="videi">
+      <!--
+        <iframe
+          width="420"
+          height="315"
+          class="youtube-video"
+          src="https://www.youtube.com/embed/c_5o7RdhAA4"
+        >
+        </iframe>
+        <iframe
+          src="https://youtube.com/embed/8JdwZ2xW09U"
+          width="420"
+          height="315"
+          class="youtube-video"
+        ></iframe>
+      -->
+    </div>
+    <div class="cv-links">
+      <!-- Add your Europass CV link below -->
+      <a
+        href="https://europa.eu/europass/eportfolio/api/eprofile/shared-profile/maj-mohar/77ae228e-119c-4855-b3b8-db07cb0735ea?view=html"
+        target="_blank"
+        rel="noopener noreferrer"
       >
-      </iframe>
-      <iframe
-        src="https://youtube.com/embed/8JdwZ2xW09U"
-        width="420"
-        height="315"
-        class="youtube-video"
-      ></iframe>
-    -->
-  </div>
-  <div class="cv-links">
-    <!-- Add your Europass CV link below -->
-    <a
-      href="https://europa.eu/europass/eportfolio/api/eprofile/shared-profile/maj-mohar/77ae228e-119c-4855-b3b8-db07cb0735ea?view=html"
-      target="_blank"
-      rel="noopener noreferrer"
-    >
-      <button>See My Europass CV</button>
-    </a>
+        <button>See My Europass CV</button>
+      </a>
+    </div>
   </div>
 </section>

--- a/files/html-parts/contact.html
+++ b/files/html-parts/contact.html
@@ -1,46 +1,43 @@
-<div class="header-image">
-    <section id="contact">
+<section id="contact" class="section-wrapper">
+  <div class="section-panel contact-panel">
+    <div class="section-heading">
       <h2>Find Me Online</h2>
-      <ul class="contact-list">
-        <li class="contact-item">
-          <a href="https://github.com/majmohar4" target="_blank">
-            <img src="./files/icons/github-icon.svg" alt="GitHub" />
-            <span>GitHub</span>
-          </a>
-        </li>
-        <li class="contact-item">
-          <a href="https://www.youtube.com/@majmohar" target="_blank">
-            <img src="./files/icons/youtube-icon.svg" alt="YouTube" />
-            <span>YouTube</span>
-          </a>
-        </li>
-        <li class="contact-item">
-          <a href="mailto:maj.mohar4@gmail.com">
-            <img src="./files/icons/gmail-icon.svg" alt="Gmail" />
-            <span>Gmail</span>
-          </a>
-        </li>
-        <li class="contact-item">
-          <a
-            href="https://discord.com/users/1014769833688182825"
-            target="_blank"
-          >
-            <img src="./files/icons/discord-icon.svg" alt="Discord" />
-            <span>Discord</span>
-          </a>
-        </li>
-        <li class="contact-item">
-          <a
-            href="https://www.linkedin.com/in/maj-mohar-393984305/"
-            target="_blank"
-          >
-            <img src="./files/icons/linkedin-icon.svg" alt="LinkedIn" />
-            <span>LinkedIn</span>
-          </a>
-        </li>
-      </ul>
-    </section>
-    <footer>
-      <p>&copy; 2025 Maj Mohar</p>
-    </footer>
+      <p class="section-lede">Let's connect on the platforms where I'm most active.</p>
     </div>
+    <ul class="contact-grid">
+      <li class="contact-card">
+        <a href="https://github.com/majmohar4" target="_blank" rel="noopener noreferrer">
+          <img src="./files/icons/github-icon.svg" alt="GitHub" />
+          <span>GitHub</span>
+        </a>
+      </li>
+      <li class="contact-card">
+        <a href="https://www.youtube.com/@majmohar" target="_blank" rel="noopener noreferrer">
+          <img src="./files/icons/youtube-icon.svg" alt="YouTube" />
+          <span>YouTube</span>
+        </a>
+      </li>
+      <li class="contact-card">
+        <a href="mailto:maj.mohar4@gmail.com">
+          <img src="./files/icons/gmail-icon.svg" alt="Gmail" />
+          <span>Gmail</span>
+        </a>
+      </li>
+      <li class="contact-card">
+        <a href="https://discord.com/users/1014769833688182825" target="_blank" rel="noopener noreferrer">
+          <img src="./files/icons/discord-icon.svg" alt="Discord" />
+          <span>Discord</span>
+        </a>
+      </li>
+      <li class="contact-card">
+        <a href="https://www.linkedin.com/in/maj-mohar-393984305/" target="_blank" rel="noopener noreferrer">
+          <img src="./files/icons/linkedin-icon.svg" alt="LinkedIn" />
+          <span>LinkedIn</span>
+        </a>
+      </li>
+    </ul>
+  </div>
+</section>
+<footer class="site-footer">
+  <p>&copy; 2025 Maj Mohar</p>
+</footer>

--- a/files/html-parts/friends.html
+++ b/files/html-parts/friends.html
@@ -1,21 +1,49 @@
 <section id="friends" class="friends-section">
-    <h2>Friends I Know</h2>
-    <div class="friends-list">
-      <div class="friend-item" onclick="window.open('https://cadez.eu', '_blank')">
-        <span class="friend-name">Lin Čadež</span>
-        <span class="friend-description">Backend developer, drone pilot & BlueJ lover</span>
+  <h2>Friends I Know</h2>
+  <p class="friends-intro">
+    A few of the creatives and problem solvers I collaborate with on school
+    projects and side adventures.
+  </p>
+  <div class="friends-grid">
+    <a class="friend-card" href="https://cadez.eu" target="_blank" rel="noopener noreferrer">
+      <div class="friend-card-content">
+        <span class="friend-avatar" aria-hidden="true">LC</span>
+        <div class="friend-text">
+          <h3 class="friend-name">Lin Čadež</h3>
+          <p class="friend-description">Backend developer, drone pilot &amp; BlueJ lover</p>
+        </div>
+        <span class="friend-arrow" aria-hidden="true">→</span>
       </div>
-      <div class="friend-item" onclick="window.open('https://cernetic.cc', '_blank')">
-        <span class="friend-name">Jaka Černetič</span>
-        <span class="friend-description">Designer and reddit user</span>
+    </a>
+    <a class="friend-card" href="https://cernetic.cc" target="_blank" rel="noopener noreferrer">
+      <div class="friend-card-content">
+        <span class="friend-avatar" aria-hidden="true">JČ</span>
+        <div class="friend-text">
+          <h3 class="friend-name">Jaka Černetič</h3>
+          <p class="friend-description">Designer, storyteller &amp; resident Reddit user</p>
+        </div>
+        <span class="friend-arrow" aria-hidden="true">→</span>
       </div>
-      <div class="friend-item" onclick="window.open('https://akva-design.com/', '_blank')">
-        <span class="friend-name">Andriy Gryban</span>
-        <span class="friend-description">Web developer & designer</span>
+    </a>
+    <a class="friend-card" href="https://akva-design.com/" target="_blank" rel="noopener noreferrer">
+      <div class="friend-card-content">
+        <span class="friend-avatar" aria-hidden="true">AG</span>
+        <div class="friend-text">
+          <h3 class="friend-name">Andriy Gryban</h3>
+          <p class="friend-description">Web developer with a sharp eye for design</p>
+        </div>
+        <span class="friend-arrow" aria-hidden="true">→</span>
       </div>
-      <div class="friend-item" onclick="window.open('https://dodoworks.neocities.org/', '_blank')">
-        <span class="friend-name">Dorian Mahnič Dobrovoljc</span>
-        <span class="friend-description">Java lover & amateur radio operator</span>
+    </a>
+    <a class="friend-card" href="https://dodoworks.neocities.org/" target="_blank" rel="noopener noreferrer">
+      <div class="friend-card-content">
+        <span class="friend-avatar" aria-hidden="true">DM</span>
+        <div class="friend-text">
+          <h3 class="friend-name">Dorian Mahnič Dobrovoljc</h3>
+          <p class="friend-description">Java enthusiast &amp; amateur radio operator</p>
+        </div>
+        <span class="friend-arrow" aria-hidden="true">→</span>
       </div>
-    </div>
-  </section>
+    </a>
+  </div>
+</section>

--- a/files/html-parts/friends.html
+++ b/files/html-parts/friends.html
@@ -1,49 +1,52 @@
-<section id="friends" class="friends-section">
-  <h2>Friends I Know</h2>
-  <p class="friends-intro">
-    A few of the creatives and problem solvers I collaborate with on school
-    projects and side adventures.
-  </p>
-  <div class="friends-grid">
-    <a class="friend-card" href="https://cadez.eu" target="_blank" rel="noopener noreferrer">
-      <div class="friend-card-content">
-        <span class="friend-avatar" aria-hidden="true">LC</span>
-        <div class="friend-text">
-          <h3 class="friend-name">Lin Čadež</h3>
-          <p class="friend-description">Backend developer, drone pilot &amp; BlueJ lover</p>
+<section id="friends" class="section-wrapper">
+  <div class="section-panel friends-panel">
+    <div class="section-heading">
+      <h2>Friends I Know</h2>
+      <p class="section-lede">
+        A few of the creatives and problem solvers I collaborate with on school projects and side adventures.
+      </p>
+    </div>
+    <div class="friends-grid">
+      <a class="friend-card" href="https://cadez.eu" target="_blank" rel="noopener noreferrer">
+        <div class="friend-card-content">
+          <span class="friend-avatar" aria-hidden="true">LC</span>
+          <div class="friend-text">
+            <h3 class="friend-name">Lin Čadež</h3>
+            <p class="friend-description">Backend developer, drone pilot &amp; BlueJ lover</p>
+          </div>
+          <span class="friend-arrow" aria-hidden="true">→</span>
         </div>
-        <span class="friend-arrow" aria-hidden="true">→</span>
-      </div>
-    </a>
-    <a class="friend-card" href="https://cernetic.cc" target="_blank" rel="noopener noreferrer">
-      <div class="friend-card-content">
-        <span class="friend-avatar" aria-hidden="true">JČ</span>
-        <div class="friend-text">
-          <h3 class="friend-name">Jaka Černetič</h3>
-          <p class="friend-description">Designer, storyteller &amp; resident Reddit user</p>
+      </a>
+      <a class="friend-card" href="https://cernetic.cc" target="_blank" rel="noopener noreferrer">
+        <div class="friend-card-content">
+          <span class="friend-avatar" aria-hidden="true">JČ</span>
+          <div class="friend-text">
+            <h3 class="friend-name">Jaka Černetič</h3>
+            <p class="friend-description">Designer, storyteller &amp; resident Reddit user</p>
+          </div>
+          <span class="friend-arrow" aria-hidden="true">→</span>
         </div>
-        <span class="friend-arrow" aria-hidden="true">→</span>
-      </div>
-    </a>
-    <a class="friend-card" href="https://akva-design.com/" target="_blank" rel="noopener noreferrer">
-      <div class="friend-card-content">
-        <span class="friend-avatar" aria-hidden="true">AG</span>
-        <div class="friend-text">
-          <h3 class="friend-name">Andriy Gryban</h3>
-          <p class="friend-description">Web developer with a sharp eye for design</p>
+      </a>
+      <a class="friend-card" href="https://akva-design.com/" target="_blank" rel="noopener noreferrer">
+        <div class="friend-card-content">
+          <span class="friend-avatar" aria-hidden="true">AG</span>
+          <div class="friend-text">
+            <h3 class="friend-name">Andriy Gryban</h3>
+            <p class="friend-description">Web developer with a sharp eye for design</p>
+          </div>
+          <span class="friend-arrow" aria-hidden="true">→</span>
         </div>
-        <span class="friend-arrow" aria-hidden="true">→</span>
-      </div>
-    </a>
-    <a class="friend-card" href="https://dodoworks.neocities.org/" target="_blank" rel="noopener noreferrer">
-      <div class="friend-card-content">
-        <span class="friend-avatar" aria-hidden="true">DM</span>
-        <div class="friend-text">
-          <h3 class="friend-name">Dorian Mahnič Dobrovoljc</h3>
-          <p class="friend-description">Java enthusiast &amp; amateur radio operator</p>
+      </a>
+      <a class="friend-card" href="https://dodoworks.neocities.org/" target="_blank" rel="noopener noreferrer">
+        <div class="friend-card-content">
+          <span class="friend-avatar" aria-hidden="true">DM</span>
+          <div class="friend-text">
+            <h3 class="friend-name">Dorian Mahnič Dobrovoljc</h3>
+            <p class="friend-description">Java enthusiast &amp; amateur radio operator</p>
+          </div>
+          <span class="friend-arrow" aria-hidden="true">→</span>
         </div>
-        <span class="friend-arrow" aria-hidden="true">→</span>
-      </div>
-    </a>
+      </a>
+    </div>
   </div>
 </section>

--- a/files/html-parts/projects.html
+++ b/files/html-parts/projects.html
@@ -1,80 +1,75 @@
-<section id="projects">
-    <h2>Projects</h2>
-    <div class="description">
-      <ul>
-        <li>
-          <h3>KrokyPlus</h3>
-          <p>
-            My friends and I always forget to order us food for school, so we,
-            in our laziness, made an AI to order it for us.
-          </p>
-          <p>
-            <img src="./files/icons/js-icon.svg" alt="JS Icon" />
-            <img src="./files/icons/react-icon.svg" alt="ReactJS Icon" />
-            <img src="./files/icons/css-icon.svg" alt="CSS Icon" />
-            <img src="./files/icons/html-icon.svg" alt="HTML Icon" />
-          </p>
-          <p>Github and webpage:</p>
-          <div class="links">
-            <p>
-              <a href="https://krokyplus.si/" target="_blank">
-                <img
-                  src="./files/icons/website-icon.svg"
-                  alt="Website Icon"
-                />
-              </a>
-            </p>
-            <p>
-              <a href="https://github.com/username/repo" target="_blank">
-                <img src="./files/icons/github-icon.svg" alt="GitHub Icon" />
-              </a>
-            </p>
-          </div>
-        </li>
-        <li>
-          <h3>Assembly Arduino Sound Effects</h3>
-          <p>
-            Developed an Arduino project where I utilized assembly language to
-            create sound effects for various events. This project helped me
-            deepen my understanding of low-level programming and embedded
-            systems while exploring audio manipulation.
-          </p>
-          <p>GitHub:</p>
-          <p>
-            <a
-              href="https://github.com/majmohar4/Assembly-projekt"
-              target="_blank"
-            >
-              <img src="./files/icons/github-icon.svg" alt="GitHub Icon" />
-            </a>
-          </p>
-        </li>
-        <li>
-          <h3>Batch (Basic) Project</h3>
-          <p>
-            Created a simple batch script for school work that is annoying to
-            any use.
-          </p>
-          <p>GitHub:</p>
-          <p>
-            <a href="https://github.com/majmohar4/Lab_vaje" target="_blank">
-              <img src="./files/icons/github-icon.svg" alt="GitHub Icon" />
-            </a>
-          </p>
-        </li>
-        <li>
-          <h3>This website MajMohar.eu</h3>
-          <p>Wrote simple portfolio.</p>
-          <p>GitHub:</p>
-          <p>
-            <a
-              href="https://github.com/majmohar4/majmohar-new"
-              target="_blank"
-            >
-              <img src="./files/icons/github-icon.svg" alt="GitHub Icon" />
-            </a>
-          </p>
-        </li>
-      </ul>
+<section id="projects" class="section-wrapper">
+  <div class="section-panel">
+    <div class="section-heading">
+      <h2>Projects</h2>
+      <p class="section-lede">A selection of school and personal builds I keep iterating on.</p>
     </div>
-  </section>
+    <div class="projects-grid">
+      <article class="project-card">
+        <div class="project-header">
+          <h3>KrokyPlus</h3>
+          <div class="project-stack" aria-label="Stack used for KrokyPlus">
+            <img src="./files/icons/js-icon.svg" alt="JavaScript" />
+            <img src="./files/icons/react-icon.svg" alt="React" />
+            <img src="./files/icons/css-icon.svg" alt="CSS" />
+            <img src="./files/icons/html-icon.svg" alt="HTML" />
+          </div>
+        </div>
+        <p class="project-description">
+          My friends and I always forget to order us food for school, so we, in our laziness, made an AI to order it for us.
+        </p>
+        <div class="project-links" aria-label="KrokyPlus links">
+          <a href="https://krokyplus.si/" target="_blank" rel="noopener noreferrer">
+            <img src="./files/icons/website-icon.svg" alt="Open website" />
+            <span>Website</span>
+          </a>
+          <a href="https://github.com/username/repo" target="_blank" rel="noopener noreferrer">
+            <img src="./files/icons/github-icon.svg" alt="View on GitHub" />
+            <span>GitHub</span>
+          </a>
+        </div>
+      </article>
+      <article class="project-card">
+        <div class="project-header">
+          <h3>Assembly Arduino Sound Effects</h3>
+        </div>
+        <p class="project-description">
+          Developed an Arduino project where I utilized assembly language to create sound effects for various events.
+          This project helped me deepen my understanding of low-level programming and embedded systems while exploring audio manipulation.
+        </p>
+        <div class="project-links" aria-label="Assembly Arduino Sound Effects links">
+          <a href="https://github.com/majmohar4/Assembly-projekt" target="_blank" rel="noopener noreferrer">
+            <img src="./files/icons/github-icon.svg" alt="View on GitHub" />
+            <span>GitHub</span>
+          </a>
+        </div>
+      </article>
+      <article class="project-card">
+        <div class="project-header">
+          <h3>Batch (Basic) Project</h3>
+        </div>
+        <p class="project-description">
+          Created a simple batch script for school work that is annoying to any use.
+        </p>
+        <div class="project-links" aria-label="Batch project links">
+          <a href="https://github.com/majmohar4/Lab_vaje" target="_blank" rel="noopener noreferrer">
+            <img src="./files/icons/github-icon.svg" alt="View on GitHub" />
+            <span>GitHub</span>
+          </a>
+        </div>
+      </article>
+      <article class="project-card">
+        <div class="project-header">
+          <h3>This website MajMohar.eu</h3>
+        </div>
+        <p class="project-description">Wrote simple portfolio.</p>
+        <div class="project-links" aria-label="Website project links">
+          <a href="https://github.com/majmohar4/majmohar-new" target="_blank" rel="noopener noreferrer">
+            <img src="./files/icons/github-icon.svg" alt="View on GitHub" />
+            <span>GitHub</span>
+          </a>
+        </div>
+      </article>
+    </div>
+  </div>
+</section>

--- a/files/html-parts/skills.html
+++ b/files/html-parts/skills.html
@@ -1,103 +1,108 @@
-<section id="skills">
-  <h2>My Skills</h2>
-  <p>
-      I enjoy working with JavaScript, Java, and C++ (focused on Arduino & ESP32 framework). I have experience with various tools and frameworks that help me build efficient projects.
-  </p>
-
-  <h3>Languages I’m Learning:</h3>
-  <div class="badges">
-      <div class="badge">
-          <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/javascript/javascript-original.svg" alt="JavaScript" width="20">
-          <p>JavaScript</p>
-      </div>
-      <div class="badge">
-          <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/java/java-original.svg" alt="Java" width="20">
-          <p>Java</p>
-      </div>
-      <div class="badge">
-          <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/cplusplus/cplusplus-original.svg" alt="C++" width="20">
-          <p>C++ (Arduino & ESP32)</p>
-      </div>
-  </div>
-
-  <h3>Languages & Technologies I’ve Used:</h3>
-  <div class="badges">
-      <div class="badge">
-          <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/nodejs/nodejs-original.svg" alt="Node.js" width="20">
-          <p>Node.js</p>
-      </div>
-      <div class="badge">
-          <img src="../../files/icons/react-icon.svg" alt="React Native" width="20">
-          <p>React Native</p>
-      </div>
-      <div class="badge">
-          <p>CMD</p>
-      </div>
-      <div class="badge">
-          <p>Batch</p>
-      </div>
-      <div class="badge">
-          <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/git/git-original.svg" alt="Git" width="20">
-          <p>Git</p>
-      </div>
-      <div class="badge">
-          <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/cplusplus/cplusplus-original.svg" alt="C++" width="20">
-          <p>C++</p>
-      </div>
-  </div>
-
-  <h3>Frameworks & Libraries:</h3>
-  <div class="badges">
-      <div class="badge">
-          <img src="../../files/icons/react-icon.svg" alt="React Native" width="20">
-          <p>React Native</p>
-      </div>
-      <div class="badge">
-          <p>ESP32 Framework</p>
-      </div>
-      <div class="badge">
-          <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/nodejs/nodejs-original.svg" alt="Node.js" width="20">
-          <p>Node.js</p>
-      </div>
-  </div>
-
-  <h3>Tools I Use:</h3>
-  <div class="badges">
-      <div class="badge">
-          <img src="../../files/icons/vs-code.svg" alt="Visual Studio" width="20">
-          <p>VS Code</p>
-      </div>
-      <div class="badge">
-          <img src="../../files/icons/alt-tab.png" alt="Alt-Tab" width="20">
-          <p>Alt-Tab</p>
-      </div>
-      <div class="badge">
-          <img src="../../files/icons/maccy.png" alt="Maccy" width="20">
-          <p>Maccy</p>
-      </div>
-      <div class="badge">
-          <img src="../../files/icons/aldente.png" alt="AlDente" width="20">
-          <p>AlDente</p>
-      </div>
-      <div class="badge">
-          <img src="../../files/icons/neardrop.avif" alt="NearDrop" width="20">
-          <p>NearDrop</p>
-      </div>
-      <div class="badge">
-          <img src="../../files/icons/raycast.png" alt="Raycast" width="20">
-          <p>Raycast</p>
-      </div>
-      <div class="badge">
-          <img src="../../files/icons/coderunner.png" alt="CodeRunner" width="20">
-          <p>CodeRunner</p>
-      </div>
-      <div class="badge">
-          <img src="../../files/icons/brave.svg" alt="Brave" width="20">
-          <p>Brave</p>
-      </div>
-      <div class="badge">
-          <img src="../../files/icons/localsend.avif" alt="LocalSend" width="20">
-          <p>LocalSend</p>
-      </div>
+<section id="skills" class="section-wrapper">
+  <div class="section-panel">
+    <div class="section-heading">
+      <h2>My Skills</h2>
+      <p class="section-lede">
+        I enjoy working with JavaScript, Java, and C++ (focused on Arduino &amp; ESP32 framework).
+        I have experience with various tools and frameworks that help me build efficient projects.
+      </p>
+    </div>
+    <div class="skills-groups">
+      <article class="skill-group">
+        <h3>Languages I’m Learning</h3>
+        <div class="badges">
+          <div class="badge">
+            <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/javascript/javascript-original.svg" alt="JavaScript" width="20" />
+            <p>JavaScript</p>
+          </div>
+          <div class="badge">
+            <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/java/java-original.svg" alt="Java" width="20" />
+            <p>Java</p>
+          </div>
+          <div class="badge">
+            <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/cplusplus/cplusplus-original.svg" alt="C++" width="20" />
+            <p>C++ (Arduino &amp; ESP32)</p>
+          </div>
+        </div>
+      </article>
+      <article class="skill-group">
+        <h3>Languages &amp; Technologies I’ve Used</h3>
+        <div class="badges">
+          <div class="badge">
+            <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/nodejs/nodejs-original.svg" alt="Node.js" width="20" />
+            <p>Node.js</p>
+          </div>
+          <div class="badge">
+            <img src="./files/icons/react-icon.svg" alt="React Native" width="20" />
+            <p>React Native</p>
+          </div>
+          <div class="badge"><p>CMD</p></div>
+          <div class="badge"><p>Batch</p></div>
+          <div class="badge">
+            <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/git/git-original.svg" alt="Git" width="20" />
+            <p>Git</p>
+          </div>
+          <div class="badge">
+            <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/cplusplus/cplusplus-original.svg" alt="C++" width="20" />
+            <p>C++</p>
+          </div>
+        </div>
+      </article>
+      <article class="skill-group">
+        <h3>Frameworks &amp; Libraries</h3>
+        <div class="badges">
+          <div class="badge">
+            <img src="./files/icons/react-icon.svg" alt="React Native" width="20" />
+            <p>React Native</p>
+          </div>
+          <div class="badge"><p>ESP32 Framework</p></div>
+          <div class="badge">
+            <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/nodejs/nodejs-original.svg" alt="Node.js" width="20" />
+            <p>Node.js</p>
+          </div>
+        </div>
+      </article>
+      <article class="skill-group">
+        <h3>Tools I Use</h3>
+        <div class="badges">
+          <div class="badge">
+            <img src="./files/icons/vs-code.svg" alt="Visual Studio" width="20" />
+            <p>VS Code</p>
+          </div>
+          <div class="badge">
+            <img src="./files/icons/alt-tab.png" alt="Alt-Tab" width="20" />
+            <p>Alt-Tab</p>
+          </div>
+          <div class="badge">
+            <img src="./files/icons/maccy.png" alt="Maccy" width="20" />
+            <p>Maccy</p>
+          </div>
+          <div class="badge">
+            <img src="./files/icons/aldente.png" alt="AlDente" width="20" />
+            <p>AlDente</p>
+          </div>
+          <div class="badge">
+            <img src="./files/icons/neardrop.avif" alt="NearDrop" width="20" />
+            <p>NearDrop</p>
+          </div>
+          <div class="badge">
+            <img src="./files/icons/raycast.png" alt="Raycast" width="20" />
+            <p>Raycast</p>
+          </div>
+          <div class="badge">
+            <img src="./files/icons/coderunner.png" alt="CodeRunner" width="20" />
+            <p>CodeRunner</p>
+          </div>
+          <div class="badge">
+            <img src="./files/icons/brave.svg" alt="Brave" width="20" />
+            <p>Brave</p>
+          </div>
+          <div class="badge">
+            <img src="./files/icons/localsend.avif" alt="LocalSend" width="20" />
+            <p>LocalSend</p>
+          </div>
+        </div>
+      </article>
+    </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- replace inline layout in the about section with a reusable container class
- tune about section styles to center content and keep the profile image responsive on small screens
- add a subtle note about my Christian faith and animation contributions in the about section copy

## Testing
- no tests were run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68d816cdf5448323921cbdf128ad6af8